### PR TITLE
Fix circular import in monitor controller

### DIFF
--- a/CIRCULAR_IMPORT_FIX.md
+++ b/CIRCULAR_IMPORT_FIX.md
@@ -1,0 +1,64 @@
+# Circular Import Fix - MonitorNap
+
+## Problem
+The application was experiencing a circular import error when packaged with PyInstaller:
+
+```
+ImportError: cannot import name 'MonitorController' from partially initialized module 'monitor_controller' 
+(most likely due to a circular import)
+```
+
+### Root Cause
+The circular dependency chain was:
+1. `monitornap.py` (line 187) → imports `MonitorController` from `monitor_controller.py`
+2. `monitor_controller.py` (line 15) → imports `log_message` from `monitornap.py`
+3. `ui_components.py` (line 15) → also imports `log_message` from `monitornap.py`
+
+This created a circular dependency where `monitornap` and `monitor_controller` depended on each other.
+
+## Solution
+Created a new independent logging module (`logging_utils.py`) that contains the logging functionality. This allows all other modules to import logging utilities without creating circular dependencies.
+
+### Changes Made
+
+1. **Created `/workspace/logging_utils.py`**
+   - Extracted `log_message()` function
+   - Extracted `LOG_CACHE` deque
+   - Extracted `DEBUG_MODE` flag
+   - Added `set_debug_mode()` helper function
+
+2. **Updated `/workspace/monitornap.py`**
+   - Removed logging function definitions
+   - Changed: `from logging_utils import log_message, LOG_CACHE, set_debug_mode`
+   - Updated debug mode setting to use `set_debug_mode()` instead of global variable
+
+3. **Updated `/workspace/monitor_controller.py`**
+   - Changed: `from logging_utils import log_message` (was `from monitornap import log_message`)
+
+4. **Updated `/workspace/ui_components.py`**
+   - Changed: `from logging_utils import log_message` (was `from monitornap import log_message`)
+
+### New Import Structure
+
+```
+logging_utils.py (no dependencies on other app modules)
+    ↑
+    ├── monitornap.py
+    ├── monitor_controller.py
+    └── ui_components.py
+```
+
+Now:
+- `logging_utils.py` has no dependencies on other app modules
+- All modules import logging from `logging_utils.py`
+- `monitornap.py` imports from `monitor_controller.py` and `ui_components.py`
+- No circular dependencies exist
+
+## Verification
+The fix has been verified to eliminate the circular import issue. The application can now be imported successfully without circular dependency errors.
+
+## Files Modified
+- ✅ Created: `logging_utils.py`
+- ✅ Modified: `monitornap.py`
+- ✅ Modified: `monitor_controller.py`
+- ✅ Modified: `ui_components.py`

--- a/FIX_SUMMARY.txt
+++ b/FIX_SUMMARY.txt
@@ -1,0 +1,69 @@
+================================================================================
+CIRCULAR IMPORT FIX - SUMMARY
+================================================================================
+
+PROBLEM IDENTIFIED:
+-------------------
+ImportError: cannot import name 'MonitorController' from partially initialized 
+module 'monitor_controller' (most likely due to a circular import)
+
+Circular dependency chain:
+  monitornap.py → monitor_controller.py → monitornap.py (CIRCULAR!)
+
+
+SOLUTION IMPLEMENTED:
+---------------------
+Created a new independent logging module to break the circular dependency.
+
+BEFORE (Circular Dependency):
+-----------------------------
+  monitornap.py
+    ├── imports: monitor_controller, ui_components
+    └── contains: log_message() function
+           ↑
+           │ (imports log_message)
+           │
+  monitor_controller.py
+    └── imports: monitornap.log_message  ← CIRCULAR!
+
+
+AFTER (Fixed):
+--------------
+  logging_utils.py (NEW!)
+    └── contains: log_message(), LOG_CACHE, DEBUG_MODE
+           ↑
+           ├─── monitornap.py
+           │      └── imports: monitor_controller, ui_components, logging_utils
+           │
+           ├─── monitor_controller.py
+           │      └── imports: logging_utils
+           │
+           └─── ui_components.py
+                  └── imports: logging_utils
+
+  ✓ NO CIRCULAR DEPENDENCIES
+
+
+FILES CHANGED:
+--------------
+[NEW]     logging_utils.py       - Independent logging module
+[MODIFIED] monitornap.py          - Import from logging_utils
+[MODIFIED] monitor_controller.py  - Import from logging_utils  
+[MODIFIED] ui_components.py       - Import from logging_utils
+
+
+VERIFICATION:
+-------------
+✓ All Python files compile without syntax errors
+✓ No circular import dependencies detected
+✓ Import structure validated
+✓ Ready for PyInstaller packaging
+
+
+NEXT STEPS:
+-----------
+1. Test the application in development mode
+2. Rebuild with PyInstaller
+3. Verify the packaged executable runs without import errors
+
+================================================================================

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -1,0 +1,36 @@
+"""Logging utilities for MonitorNap application.
+
+This module provides logging functionality that can be imported by all other modules
+without creating circular dependencies.
+"""
+
+from collections import deque
+from datetime import datetime
+
+# Logging cache and debug mode
+LOG_CACHE = deque(maxlen=10000)
+DEBUG_MODE = False
+
+def log_message(msg: str, debug: bool = False) -> None:
+    """Log a message with timestamp to both console and cache.
+    
+    Args:
+        msg: The message to log
+        debug: If True, only log when DEBUG_MODE is enabled
+    """
+    if debug and not DEBUG_MODE:
+        return
+    t = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    prefix = "[DEBUG]" if debug else "[INFO]"
+    line = f"{prefix} {t} - {msg}"
+    LOG_CACHE.append(line)
+    print(line)
+
+def set_debug_mode(enabled: bool) -> None:
+    """Set the global debug mode flag.
+    
+    Args:
+        enabled: Whether to enable debug mode
+    """
+    global DEBUG_MODE
+    DEBUG_MODE = enabled

--- a/monitor_controller.py
+++ b/monitor_controller.py
@@ -12,7 +12,7 @@ from PyQt6.QtGui import QCursor
 from monitorcontrol import get_monitors
 import screeninfo
 
-from monitornap import log_message
+from logging_utils import log_message
 
 
 class OverlayWindow:

--- a/monitornap.py
+++ b/monitornap.py
@@ -54,6 +54,11 @@ def resolve_icon_path() -> str:
 ICON_PATH = resolve_icon_path()
 
 # -------------------------------------------------------------------------------------
+# Logging Utilities
+# -------------------------------------------------------------------------------------
+from logging_utils import log_message, LOG_CACHE, set_debug_mode
+
+# -------------------------------------------------------------------------------------
 # Set Process DPI Awareness
 # -------------------------------------------------------------------------------------
 if os.name == 'nt':
@@ -61,27 +66,6 @@ if os.name == 'nt':
         ctypes.windll.shcore.SetProcessDpiAwareness(2)
     except (AttributeError, OSError) as e:
         log_message(f"Failed to set DPI awareness: {e}", debug=True)
-
-# -------------------------------------------------------------------------------------
-# Logging Utility
-# -------------------------------------------------------------------------------------
-LOG_CACHE = deque(maxlen=10000)
-DEBUG_MODE = False
-
-def log_message(msg: str, debug: bool = False) -> None:
-    """Log a message with timestamp to both console and cache.
-    
-    Args:
-        msg: The message to log
-        debug: If True, only log when DEBUG_MODE is enabled
-    """
-    if debug and not DEBUG_MODE:
-        return
-    t = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    prefix = "[DEBUG]" if debug else "[INFO]"
-    line = f"{prefix} {t} - {msg}"
-    LOG_CACHE.append(line)
-    print(line)
 
 # -------------------------------------------------------------------------------------
 # Configuration Manager
@@ -891,8 +875,7 @@ class MonitorNapApplication(QApplication):
         self.config_manager = config_manager
         self.config = config_manager.config
         # Set global debug mode flag
-        global DEBUG_MODE
-        DEBUG_MODE = bool(self.config.get("debug_mode", False))
+        set_debug_mode(bool(self.config.get("debug_mode", False)))
 
         self.controllers = []
         if not self.config["monitors"]:

--- a/ui_components.py
+++ b/ui_components.py
@@ -12,7 +12,7 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtGui import QColor
 
-from monitornap import log_message
+from logging_utils import log_message
 
 
 class MonitorSettingsWidget(QGroupBox):


### PR DESCRIPTION
Extract logging utilities to a new module to resolve a circular import error.

The circular dependency occurred because `monitornap.py` imported `MonitorController` from `monitor_controller.py`, while `monitor_controller.py` (and `ui_components.py`) imported `log_message` from `monitornap.py`. This issue was particularly problematic when packaging with PyInstaller. Moving the shared logging functionality to `logging_utils.py` breaks this cycle.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2953f65-148e-420e-8f78-6d645ee7cd8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b2953f65-148e-420e-8f78-6d645ee7cd8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

